### PR TITLE
Benchmark frame decoder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,16 @@ clap = { version = "2.33", optional = true }
 env_logger = { version = "0.7", optional = true }
 termcolor = { version = "1", optional = true }
 
+[dev-dependencies]
+bencher = "0.1"
+
 [features]
 cmd = ["clap", "env_logger", "termcolor"]
 
 [[bin]]
 name = "gift"
 required-features = ["cmd"]
+
+[[bench]]
+name = "decode"
+harness = false

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -1,0 +1,17 @@
+use bencher::{benchmark_group, benchmark_main, black_box, Bencher};
+use gift::Decoder;
+use std::io::Cursor;
+
+fn decode_logo_frames(bencher: &mut Bencher) {
+    let logo = include_bytes!("../res/gift_logo.gif") as &[u8];
+
+    bencher.iter(|| {
+        let decoder = Decoder::new(Cursor::new(black_box(logo))).into_frames();
+        for frame in decoder {
+            black_box(frame.unwrap());
+        }
+    });
+}
+
+benchmark_group!(benches, decode_logo_frames);
+benchmark_main!(benches);


### PR DESCRIPTION
Thanks for sharing this crate! I like the clean design around blocks.

I am currently investigating some performance issues, so I added this benchmark. Baseline for me:
```
$ cargo bench
[...]
test decode_logo_frames ... bench:   7,396,730 ns/iter (+/- 3,853,928)
```