### PR TITLE
Allow encoding/decoding without BufWriter/BufReader.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,7 +6,7 @@
 use crate::block::*;
 use crate::error::Error;
 use pix::{Raster, RasterBuilder, Region, Rgba8};
-use std::io::{BufReader, ErrorKind, Read};
+use std::io::{ErrorKind, Read};
 
 /// Buffer size (must be at least as large as a color table with 256 entries)
 const BUF_SZ: usize = 1024;
@@ -43,7 +43,7 @@ const BUF_SZ: usize = 1024;
 ///
 pub struct Blocks<R: Read> {
     /// Buffered reader
-    reader: BufReader<R>,
+    reader: R,
     /// Maximum image size in bytes
     max_image_sz: Option<usize>,
     /// Data buffer
@@ -77,7 +77,7 @@ impl<R: Read> Iterator for Blocks<R> {
 
 impl<R: Read> Blocks<R> {
     /// Create a new block iterator
-    pub(crate) fn new(reader: BufReader<R>, max_image_sz: Option<usize>)
+    pub(crate) fn new(reader: R, max_image_sz: Option<usize>)
         -> Self
     {
         use self::BlockCode::Header_;

--- a/src/private.rs
+++ b/src/private.rs
@@ -43,16 +43,22 @@ use std::io::{BufReader, BufWriter, Read, Write};
 ///
 pub struct Decoder<R: Read> {
     /// Reader for input data
-    reader: BufReader<R>,
+    reader: R,
     /// Maximum image size, in bytes
     max_image_sz: Option<usize>,
 }
 
+impl<R: Read> Decoder<BufReader<R>> {
+    /// Create a new GIF decoder.
+    pub fn new(reader: R) -> Self {
+        Self::new_unbuffered(BufReader::new(reader))
+    }
+}
 impl<R: Read> Decoder<R> {
-    /// Create a new Decoder
-    pub fn new(r: R) -> Self {
+    /// Create a new unbuffered GIF decoder.
+    pub fn new_unbuffered(reader: R) -> Self {
         Decoder {
-            reader: BufReader::new(r),
+            reader,
             max_image_sz: Some(1 << 25),
         }
     }
@@ -99,14 +105,19 @@ impl<R: Read> IntoIterator for Decoder<R> {
 /// [into_raster_enc]: struct.Encoder.html#method.into_raster_enc
 pub struct Encoder<W: Write> {
     /// Writer for output data
-    writer: BufWriter<W>,
+    writer: W,
 }
-
-impl<W: Write> Encoder<W> {
+impl<W: Write> Encoder<BufWriter<W>> {
     /// Create a new GIF encoder.
-    pub fn new(w: W) -> Self {
+    pub fn new(writer: W) -> Self {
+        Self::new_unbuffered(BufWriter::new(writer))
+    }
+}
+impl<W: Write> Encoder<W> {
+    /// Create a new unbuffered GIF encoder.
+    pub fn new_unbuffered(writer: W) -> Self {
         Encoder {
-            writer: BufWriter::new(w),
+            writer,
         }
     }
     /// Convert into a block encoder.


### PR DESCRIPTION
This adds `{Encoder,Decoder}::new_unbuffered()`.

I am using gift to encode Gifs in memory, so it's nice to have the option to not add another layer of buffering.